### PR TITLE
feat : add markdown message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ See https://api.slack.com/bot-users for information on setting up and installing
 
 - `channel`: The Slack channel ID to send the message to
 
+- `mrkdwn` : (optional) Determines whether the text field is rendered according to mrkdwn formatting or not. Defaults to true.
+
 ## Example Usage
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,14 @@ async function run(): Promise<void> {
         const slackToken = core.getInput("slack-token", { required: true });
         const channel = core.getInput("channel", { required: true });
         const message = core.getInput("message", { required: true });
+        const markdown = core.getInput("mrkdwn", {required: false });
 
         // Send slack message
         const slackWebClient =  new WebClient(slackToken);
         const result = await slackWebClient.chat.postMessage({
           text: message,
-          channel: channel
+          channel: channel,
+          mrkdwn: markdown ?? false
         });
 
         if (result.ok) {


### PR DESCRIPTION
Add markdown support to allow further message personalization.

Ref : [Slack API](https://api.slack.com/reference/messaging/payload)